### PR TITLE
Version check always fails for Python3

### DIFF
--- a/pycp2k/cp2k.py
+++ b/pycp2k/cp2k.py
@@ -251,8 +251,8 @@ class CP2K(object):
         command_for_version_check = " ".join([self.cp2k_command, "-v "])
         version_result = check_output(command_for_version_check, shell=True, cwd=working_directory)
         result_lines = version_result.splitlines()
-        run_version = result_lines[0].split()[2]
-        run_revision = result_lines[1].split()[-1]
+        run_version = result_lines[0].split()[2].decode()
+        run_revision = result_lines[1].split()[-1].decode()
         build_version = pycp2k.config.build_version
         build_revision = pycp2k.config.build_revision
 


### PR DESCRIPTION
For Python3, `run_version` and `run_revision` are bytes, and
`build_version` and `build_revision` are strings.
This makes a version-check failure.

How about using `decode()` method of bytes?
I confirmed it works for Python3.