### PR TITLE
Fix CP2k 2026.1 input files

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,15 +199,18 @@ with the appropriate changes.
 4. Section and keyword names which include the plus sign '+' have been renamed
    so that it is replaced with 'PLUS'. This is because python doesn't allow the
    plus sign within variable names.
-5. Section and keyword names which include the minus/hyphen sign '-' have been
+5. Section and keyword names which include a dot '.' have been renamed so that
+   it is replaced with 'DOT'. This is because python doesn't allow the dot
+   within variable names.
+6. Section and keyword names which include the minus/hyphen sign '-' have been
    renamed so that it is replaced wih '_'. This is because python doesn't allow
    the minus/hyphen sign within variable names.
-6. All the repeatable sections X have to be added with a function 'X\_add()'.
+7. All the repeatable sections X have to be added with a function 'X\_add()'.
    This function returns a reference to the newly created object which you
    should store into a new variable for later access. Optionally you can
    provide the 'Section\_parameters' as an argument to this function. The list
    of the repeatable sections can be accessed from attribute 'X\_list'.
-7. You can use aliases and even use several aliases for the same item in the
+8. You can use aliases and even use several aliases for the same item in the
    scripts. However, the default name will be used in the input file.
 
 <a name="contact"></a>

--- a/inputparser.py
+++ b/inputparser.py
@@ -26,6 +26,10 @@ def validify_section(string):
         changed = True
         string = string.replace("+", "PLUS")
 
+    if "." in string:
+        changed = True
+        string = string.replace(".", "DOT")
+
     if string[0].isdigit():
         changed = True
         string = "NUM" + string
@@ -50,7 +54,7 @@ def validify_keyword(string):
     if string == None:
         print("    Keyword None replaced with NO_DEFAULT")
         return "NO_DEFAULT"
-    
+
     if "-" in string:
         changed = True
         string = string.replace("-", "_")
@@ -58,6 +62,10 @@ def validify_keyword(string):
     if "+" in string:
         changed = True
         string = string.replace("+", "PLUS")
+
+    if "." in string:
+        changed = True
+        string = string.replace(".", "DOT")
 
     if string[0].isdigit():
         changed = True
@@ -255,6 +263,7 @@ def recursive_class_creation(section, level, class_dictionary, version_dictionar
         member_name = subsection.find("NAME").text
         member_name = member_name.replace("-", "_")
         member_name = member_name.replace("+", "PLUS")
+        member_name = member_name.replace(".", "DOT")
         if member_name[0].isdigit():
             member_name = "_" + member_name
         imports.append("from .{0} import {0}".format(member_class_name))


### PR DESCRIPTION
The 2026.1 release of CP2k introduces an interface to SMEAGOL. Since SMEAGOL uses dots (.) to mark subsections in its parameters and CP2k mirrors all the [inputs](https://manual.cp2k.org/trunk/CP2K_INPUT/FORCE_EVAL/DFT/SMEAGOL.html), pycp2k does currently not work with the new CP2k version.

The error only arises at runtime:
```
>>> import pycp2k
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    import pycp2k
  File "./repos/pycp2k/pycp2k/__init__.py", line 1, in <module>
    from .cp2k import CP2K
  File "./repos/pycp2k/pycp2k/cp2k.py", line 3, in <module>
    from pycp2k.classes._CP2K_INPUT1 import _CP2K_INPUT1
  File "./repos/pycp2k/pycp2k/classes/_CP2K_INPUT1.py", line 7, in <module>
    from ._force_eval3 import _force_eval3
  File "./repos/pycp2k/pycp2k/classes/_force_eval3.py", line 6, in <module>
    from ._dft1 import _dft1
  File "./repos/pycp2k/pycp2k/classes/_dft1.py", line 34, in <module>
    from ._smeagol1 import _smeagol1
  File "./repos/pycp2k/pycp2k/classes/_smeagol1.py", line 2
    from ._bs.subsystemsboundaries1 import _bs.subsystemsboundaries1
                                              ^
SyntaxError: invalid syntax
```

This PR adresses this the same way PLUS signs are handled, replacing occuronces of `.` by `DOT`.